### PR TITLE
Document all LaTeX packages used in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,28 @@ Here is a [StackExchange](https://academia.stackexchange.com/questions/5414/what
 
 ## Used packages
 - `authblk`: Support for footnote style author/affiliation blocks when there are 4 or more authors
-- *under construction*
+- `babel`: American English hyphenation and language support
+- `blindtext`: Placeholder ("lorem ipsum" style) text used throughout the template example
+- `booktabs`: Publication-quality horizontal rules for tables (`\toprule`, `\midrule`, `\bottomrule`)
+- `caption`: Custom caption formatting with bold labels (`TABLE` and `FIGURE`) printed on a separate line above the caption text
+- `csquotes`: Context-sensitive quotation marks, used as a companion to `babel`
+- `enumitem`: Customization of list environments to match AOM indentation and spacing
+- `endfloat`: Automatic deferral of all tables and figures to the end of the manuscript per AOM requirements, with in-text placement markers inserted automatically
+- `fancyhdr`: Custom page headers; used to display the submission ID on the abstract page
+- `fontenc`: T1 font encoding for correct hyphenation, ligatures, and accented character support
+- `geometry`: US letter page size with one-inch margins on all sides
+- `graphicx`: Inclusion of external image files in figure environments
+- `hyperref`: Hyperlinks in the PDF output (with colored link boxes hidden); enables clickable cross-references and `\url` commands
+- `indentfirst`: Indentation of the first paragraph after each section heading, matching AOM style
+- `inputenc`: UTF-8 input encoding for special and accented characters
+- `microtype`: Micro-typographic enhancements (character protrusion and font expansion) for improved line breaking and justification
+- `multirow`: Multi-row cells in tabular environments
+- `natbib`: Author–year citations (`\citet`, `\citep`, etc.) with round parentheses; paired with the custom `aomlike.bst` bibliography style for AOM-compliant references
+- `newtx`: Times New Roman-style fonts for both text and mathematics, satisfying AOM's 12-point Times New Roman font requirement
+- `ntheorem`: Custom theorem-like environments; used to define the `hypothesis` environment with italic body text and AOM-style formatting
+- `pdflscape`: Landscape-oriented pages within the document for wide tables and figures
+- `setspace`: Double line spacing throughout the manuscript; also provides the `singlespace` environment used for section headings, reference lists, and float placement markers
+- `threeparttable`: Three-part table environment with structured notes and source lines below the table body, matching AOM's table formatting conventions
+- `titlecaps`: Automatic title-case capitalization for second-level (`\subsection`) headings
+- `titlesec`: Custom section heading formats implementing AOM's three levels of unnumbered headings (centered bold uppercase, flush-left bold title case, and bold italic run-in)
+- `titling`: Customizes `\maketitle` to produce the multi-page AOM title and abstract page structure


### PR DESCRIPTION
## Summary
Completed the "Used packages" section in the README by documenting all 24 LaTeX packages included in the template, replacing the "under construction" placeholder with comprehensive descriptions.

## Changes Made
- Added detailed documentation for all packages used in the AOM manuscript template
- Each package entry includes:
  - Package name
  - Brief description of its purpose
  - Specific functionality relevant to the template (e.g., custom commands, formatting rules)
  - How it supports AOM compliance requirements

## Notable Details
The documentation covers packages across several categories:
- **Typography & Formatting**: `babel`, `fontenc`, `inputenc`, `microtype`, `newtx`, `setspace`
- **Document Structure**: `fancyhdr`, `geometry`, `titlesec`, `titling`, `endfloat`
- **Content Elements**: `graphicx`, `hyperref`, `blindtext`, `caption`, `multirow`, `threeparttable`
- **Lists & References**: `enumitem`, `natbib`, `ntheorem`, `indentfirst`
- **Utilities**: `booktabs`, `csquotes`, `pdflscape`, `titlecaps`

Each description explains how the package contributes to meeting AOM manuscript formatting standards.

https://claude.ai/code/session_01KJr6MBawrMp1fbyMVzCvMb