### PR TITLE
Fix AOM citation style: full author list on first cite, et al. thereafter (#3)

### DIFF
--- a/AOM-LaTeX-template.tex
+++ b/AOM-LaTeX-template.tex
@@ -33,6 +33,15 @@
 \setcitestyle{notesep={: }}
 \setlength\bibhang{0.5in}
 \renewcommand{\bibsection}{}
+\makeatletter
+% AOM/APA: use "&" between authors in parenthetical citations and "and" in
+% narrative ones. The bst joins the final author with \harvardand; we make it
+% \protected so it survives into the .aux unexpanded, then natbib renders every
+% author string through \NAT@nmfmt where \ifNAT@swa is true for \citep
+% (parenthetical) and false for \citet (narrative).
+\protected\def\harvardand{and}
+\renewcommand\NAT@nmfmt[1]{{\NAT@up\ifNAT@swa\def\harvardand{\&}\fi#1}}
+\makeatother
 
 \usepackage{titling}
 \pretitle{

--- a/AOM-LaTeX-template.tex
+++ b/AOM-LaTeX-template.tex
@@ -28,7 +28,7 @@
 \usepackage[doublespacing]{setspace}
 %\setstretch{2} % uncomment for Word-like double spacing
 
-\usepackage[round]{natbib}
+\usepackage[round,longnamesfirst]{natbib}
 \bibliographystyle{aomlike}
 \setcitestyle{notesep={: }}
 \setlength\bibhang{0.5in}

--- a/AOM-LaTeX-template.tex
+++ b/AOM-LaTeX-template.tex
@@ -38,9 +38,11 @@
 % narrative ones. The bst joins the final author with \harvardand; we make it
 % \protected so it survives into the .aux unexpanded, then natbib renders every
 % author string through \NAT@nmfmt where \ifNAT@swa is true for \citep
-% (parenthetical) and false for \citet (narrative).
+% (parenthetical) and false for \citet (narrative). The \harvardand switch must
+% come before \NAT@up so the latter stays adjacent to #1 (the \Cite* variants
+% make \NAT@up a one-argument macro).
 \protected\def\harvardand{and}
-\renewcommand\NAT@nmfmt[1]{{\NAT@up\ifNAT@swa\def\harvardand{\&}\fi#1}}
+\renewcommand\NAT@nmfmt[1]{{\ifNAT@swa\def\harvardand{\&}\fi\NAT@up#1}}
 \makeatother
 
 \usepackage{titling}

--- a/AOM-LaTeX-template.tex
+++ b/AOM-LaTeX-template.tex
@@ -420,7 +420,7 @@
 
 \subsubsection{Some studies}
 
-The most cited papers in AMJ according to their website are \citet[32]{doi:10.5465/amj.2007.24160888}, \citet{doi:10.5465/amj.2007.28166119}, \citet{doi:10.5465/amj.2013.4001}, and \citet{doi:10.5465/amj.2016.4007}.\footnote{This is an example of a footnote. See \url{https://journals.aom.org/journal/amj}.} \blindtext
+The most cited papers in AMJ according to their website are \citet[32]{doi:10.5465/amj.2007.24160888}, \citet{doi:10.5465/amj.2007.28166119}, \citet{doi:10.5465/amj.2013.4001}, and \citet{doi:10.5465/amj.2016.4007}.\footnote{This is an example of a footnote. See \url{https://journals.aom.org/journal/amj}.} For works with three or more authors, the first citation lists every author (as above), whereas later citations are shortened to the first author followed by \textit{et al.}---for example, citing the last of these works again yields \citep{doi:10.5465/amj.2016.4007}. \blindtext
 
 \blindtext
 

--- a/aomlike.bst
+++ b/aomlike.bst
@@ -341,34 +341,38 @@ FUNCTION {format.authors}
 
 FUNCTION {format.full.names}
 {'s :=
-  #1 'nameptr :=
-  s num.names$ 'numnames :=
-  numnames 'namesleft :=
-    { namesleft #0 > }
-    { s nameptr
-      "{vv~}{ll}" format.name$ 't :=
-      nameptr #1 >
-        {
-          namesleft #1 >
-            { ", " * t * }
+  s num.names$ #6 >
+    { s #1 "{vv~}{ll}" format.name$ " et~al." * }   % 7+ authors: et al. even on first cite
+    { #1 'nameptr :=
+      s num.names$ 'numnames :=
+      numnames 'namesleft :=
+        { namesleft #0 > }
+        { s nameptr
+          "{vv~}{ll}" format.name$ 't :=
+          nameptr #1 >
             {
-              numnames #2 >
-                { "," * }
-                'skip$
-              if$
-              t "others" =
-                { " et~al." * }
-                { " and " * t * }
+              namesleft #1 >
+                { ", " * t * }
+                {
+                  numnames #2 >
+                    { "," * }
+                    'skip$
+                  if$
+                  t "others" =
+                    { " et~al." * }
+                    { " and " * t * }
+                  if$
+                }
               if$
             }
+            't
           if$
+          nameptr #1 + 'nameptr :=
+          namesleft #1 - 'namesleft :=
         }
-        't
-      if$
-      nameptr #1 + 'nameptr :=
-      namesleft #1 - 'namesleft :=
+      while$
     }
-  while$
+  if$
 }
 
 FUNCTION {author.editor.full}

--- a/aomlike.bst
+++ b/aomlike.bst
@@ -82,7 +82,7 @@ ENTRY
     year
   }
   {}
-  { label extra.label sort.label }
+  { label extra.label sort.label short.list }
 
 INTEGERS { output.state before.all mid.sentence after.sentence after.block }
 
@@ -174,17 +174,8 @@ FUNCTION {output.year.check}
 
 
 
-FUNCTION {output.bibitem}
-{ newline$
-  "\bibitem[" write$
-  label write$
-  "]{" write$
-  cite$ write$
-  "}" write$
-  newline$
-  ""
-  before.all 'output.state :=
-}
+% output.bibitem is defined later (after make.full.names), so that it can emit
+% the natbib author-year label format \bibitem[short(year)full]{key}.
 
 FUNCTION {fin.entry}
 { add.period$
@@ -343,6 +334,97 @@ FUNCTION {format.authors}
     { author format.names }
   if$
 }
+
+% --- natbib author-year label support (full author lists) -----------------
+% These produce the full author list used by natbib's longnamesfirst option
+% for the first citation of a multi-author work.
+
+FUNCTION {format.full.names}
+{'s :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{vv~}{ll}" format.name$ 't :=
+      nameptr #1 >
+        {
+          namesleft #1 >
+            { ", " * t * }
+            {
+              numnames #2 >
+                { "," * }
+                'skip$
+              if$
+              t "others" =
+                { " et~al." * }
+                { " and " * t * }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {author.editor.full}
+{ author empty$
+    { editor empty$
+        { "" }
+        { editor format.full.names }
+      if$
+    }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {author.full}
+{ author empty$
+    { "" }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {editor.full}
+{ editor empty$
+    { "" }
+    { editor format.full.names }
+  if$
+}
+
+FUNCTION {make.full.names}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.full
+    { type$ "proceedings" =
+        'editor.full
+        'author.full
+      if$
+    }
+  if$
+}
+
+FUNCTION {output.bibitem}
+{ newline$
+  "\bibitem[" write$
+  label write$
+  ")" make.full.names duplicate$ short.list =
+     { pop$ }
+     { * }
+   if$
+  "]{" * write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  before.all 'output.state :=
+}
+% --------------------------------------------------------------------------
 
 FUNCTION {format.key}			% this function is just for apalike
 { empty$
@@ -1023,21 +1105,31 @@ FUNCTION {editor.key.label}
   if$
 }
 
-FUNCTION {calc.label}      % this function came from ASTRON.BST (ARR)
+FUNCTION {calc.short.authors}      % natbib: short author list (e.g. "Lee et~al.")
 { type$ "book" =
   type$ "inbook" =
   or
     'author.editor.key.label
     { type$ "proceedings" =
-        'editor.key.label                       % apalike ignores organization
-        'author.key.label                       % for labeling and sorting
+        'editor.key.label
+        'author.key.label
       if$
     }
   if$
-  "\protect\astroncite{" swap$ * "}{"                   % these three lines are
-  *                                                     % for apalike, which
-  year field.or.null purify$ #-1 #4 substring$          % uses all four digits
-  *                       % the mathing closing "}" comes in at the reverse.pass
+  'short.list :=
+}
+
+FUNCTION {calc.label}              % natbib author-year label: short(year
+{ calc.short.authors
+  short.list
+  "("
+  *
+  year duplicate$ empty$
+  short.list key field.or.null = or
+     { pop$ "" }
+     'skip$
+  if$
+  *
   'label :=
 }
 
@@ -1176,13 +1268,19 @@ FUNCTION {forward.pass}
   if$
 }
 
-FUNCTION {reverse.pass}       % this function came from ASTRON.BST (ARR)
+FUNCTION {reverse.pass}       % natbib: append \natexlab-wrapped disambiguator
 { next.extra "b" =
     { "a" 'extra.label := }
     'skip$
   if$
-  label extra.label * "}" * 'label :=
   extra.label 'next.extra :=
+  extra.label
+  duplicate$ empty$
+    'skip$
+    { "{\natexlab{" swap$ * "}}" * }
+  if$
+  'extra.label :=
+  label extra.label * 'label :=
 }
 
 EXECUTE {initialize.extra.label.stuff}
@@ -1219,6 +1317,7 @@ FUNCTION {begin.bib}
     { preamble$ write$ newline$ }
   if$
   "\begin{thebibliography}{}" write$ newline$		% no labels in apalike
+  "\providecommand{\natexlab}[1]{#1}" write$ newline$
 }
 
 EXECUTE {begin.bib}

--- a/aomlike.bst
+++ b/aomlike.bst
@@ -309,13 +309,9 @@ FUNCTION {format.names}
       nameptr #1 >
 	{ namesleft #1 >
 	    { ", " * t * }
-	    { numnames #2 >
-		{ "," * }
-		'skip$
-	      if$
-	      t "others" =
-		{ " et~al." * }
-		{ " and " * t * }
+	    { t "others" =
+		{ ", et~al." * }
+		{ ", \& " * t * }
 	      if$
 	    }
 	  if$
@@ -360,7 +356,7 @@ FUNCTION {format.full.names}
                   if$
                   t "others" =
                     { " et~al." * }
-                    { " and " * t * }
+                    { " \harvardand\ " * t * }
                   if$
                 }
               if$
@@ -1064,7 +1060,7 @@ FUNCTION {format.lab.names}
 	'skip$
 	{ s #2 "{ff }{vv }{ll}{ jj}" format.name$ "others" =
 	    { " et~al." * }
-	    { " and " * s #2 "{vv~}{ll}" format.name$ * }
+	    { " \harvardand\ " * s #2 "{vv~}{ll}" format.name$ * }
 	  if$
 	}
       if$


### PR DESCRIPTION
Resolves #3: AOM in-text citations and the reference list now follow the style guide's author rules.

## What changed

**`aomlike.bst` — reworked into a natbib author-year style.** The file was an old apalike/astron-style `.bst` that emitted opaque `\protect\astroncite{names}{year}` labels and pre-truncated author lists to `et al.` for every citation, so natbib never received the full author list and its `longnamesfirst` option could not work. The citation-label machinery is now the modern natbib format `\bibitem[short(year)full]{key}`:

- added the `short.list` entry field and full-name functions (`format.full.names`, `make.full.names`, …)
- rewrote `output.bibitem` to emit short + `(year)` + full author forms
- replaced `calc.label` with `calc.short.authors` + a natbib `calc.label`
- `reverse.pass` now appends a `\natexlab`-wrapped disambiguator instead of closing the old astroncite brace; `\natexlab` is provided in `begin.bib`

All AOM **bibliography entry formatting** (bold journal/volume, page colon, `In`, `City: Publisher`, etc.) is unchanged.

**`AOM-LaTeX-template.tex`**

- enabled the `longnamesfirst` natbib option: `\usepackage[round,longnamesfirst]{natbib}`
- added a sentence to the "Some studies" subsubsection demonstrating the first-full / subsequent-`et al.` behavior
- added a small natbib hook so the author separator is context-sensitive (see below)

## Citation behavior (per the AOM Style Guide)

**Number of authors** (first-full / then-`et al.`):

| Authors | First citation | Subsequent | Reference list |
|---|---|---|---|
| 1–2 | both names | both names | all names |
| 3–6 | **all** names | `et al.` | all names |
| 7+ | **`et al.`** | `et al.` | **all names** |

**Author separator** (context-based, the APA rule):

- Narrative (`\citet`): "and" — *Eisenhardt and Graebner (2007)*, *George, Howard-Grenville, Joshi, and Tihanyi (2016)*
- Parenthetical (`\citep`): "&" — *(Eisenhardt & Graebner, 2007)*, *(Langley, Smallman, Tsoukas, & Van de Ven, 2013)*
- Reference list: "&" before the final author, always with a preceding comma — *Eisenhardt, K. M., & Graebner, M. E.*

natbib has only one global conjunction macro (`\harvardand`) and can't switch it by context on its own. The mechanism: the bst joins the final author of the in-text name forms with `\harvardand`; the template makes `\harvardand` `\protected` (so it survives into the `.aux` unexpanded) and redefines natbib's `\NAT@nmfmt` to set it to `&` when `\ifNAT@swa` is true (the `\citep` family) and leave it `and` otherwise. The reference list uses a literal `&`.

The previously-fixed page-number citation format `(Author, year: page)` continues to work.

## Verification

Compiled with TeX Live (`pdflatex` + `bibtex`, full template with hyperref). Confirmed via `pdftotext`:

- `\citet`/`\citep` × first/subsequent × 1-, 2-, 4-author works all render correctly (full list first, `et al.` after; "and" narrative vs "&" parenthetical).
- 6-author test entry: all six on first cite, `et al.` after; 7-author test entry: `et al.` on **both** first and subsequent, with all seven names still in the reference list.
- Reference list uses "&" before the final author; bold-italic titles / *City: Publisher* / page ranges unchanged.
- Full template builds with no undefined citations.

**natbib command-variant sweep.** The separator hook keys on natbib's single name-rendering macro (`\NAT@nmfmt`) and its textual/parenthetical flag (`\ifNAT@swa`), so it covers every citation command by construction. Verified the full matrix renders correctly — `\citet`/`\citep`, starred `\citet*`/`\citep*` (forced full list with the right separator), suppressed-paren `\citealt`/`\citealp`, partial `\citeauthor`/`\citeyear`/`\citeyearpar`, capitalized `\Citet`/`\Citep`/`\Citealp`, pre/post notes `\citep[see][p. 5]`, page notes `\citep[32]`, and multi-key `\citep{a,b}`.

This sweep also caught and fixed a bug: the hook originally placed the `\harvardand` switch between `\NAT@up` and the name argument, which crashed the **capitalized** variants (`\Citet`, `\Citep`, `\Citealt`, `\Citealp`, `\Citeauthor`) with "Missing } inserted." — because natbib makes `\NAT@up` a one-argument macro there. Reordered so the switch runs before `\NAT@up`. (Lowercase variants were unaffected, so the main template always compiled.)

## Out of scope

Editors after "In" still render last-name-first (*Frost, P.*) rather than the AOM *P. Frost* order — a pre-existing formatting matter, separate from this change.

https://claude.ai/code/session_014USZV977gDuSemHsJNd1nZ